### PR TITLE
updated api prompt for more cohesive output

### DIFF
--- a/voicenotes/src/app/api/generateStory/route.js
+++ b/voicenotes/src/app/api/generateStory/route.js
@@ -29,13 +29,17 @@ export async function POST(req) {
 
     const prompt = `You are an educational storytelling assitant. 
     
-    Generate a ${storyType} story for a ${gradeLevel} student. The story should be in the ${genre} genre, told in the ${narration} narration style, based on the following material:
+    Generate a ${storyType} podcast-style for a ${gradeLevel} student. The story should be in the ${genre} genre, told in the ${narration} narration style, based on the following material:
 
     ${inputText.join("\n\n")}
     
-    The story should be engaging, accurate, and appropriate for the students level of comprehension. Additionally, the story must be in a Google Text to Speech compatible format.
+    Guidelines: 
+    - The story must be engaging and easy to follow for the target grade level.
+    - Do NOT include titles, speaker labels, scene directions, or sound effects (e.g., "Narrator:", "Title:", "[music fades]", "**bold text**", etc.).
+    - Write in plain paragraph form only, suitable for text-to-speech narration.
+    - Keep the story under 500 words.
 
-    Only output the story. Begin:
+    Begin:
     `
     const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
     method: "POST",

--- a/voicenotes/src/app/frontend/create.js
+++ b/voicenotes/src/app/frontend/create.js
@@ -73,7 +73,7 @@ export default function Create({setStory, setLoadingScreen}) {
             </button>
             </div>
 
-
+            
             <div className="space-y-4">
                 {files.map((file, index) => (
                     <SourceFile key={index} file={file}/>


### PR DESCRIPTION
## Summary by Sourcery

Update the story generation API prompt to enforce a podcast-style, plain-paragraph narrative with clear formatting guidelines and length limits, and clean up minor whitespace in the frontend Create component.

Enhancements:
- Revise the generateStory prompt to specify a podcast-style narrative for grade-level students.
- Add clear guidelines to exclude titles, speaker labels, scene directions, and formatting markup.
- Enforce plain paragraph output under 500 words for text-to-speech compatibility.

Chores:
- Remove extraneous blank line in the Create component for consistent formatting.