### PR TITLE
testing mobile responsiveness edits

### DIFF
--- a/voicenotes/src/app/frontend/about.js
+++ b/voicenotes/src/app/frontend/about.js
@@ -1,6 +1,6 @@
 //about section
 import React from "react";
-import { ArrowRight} from 'lucide-react'; 
+import { ArrowRight, ArrowDown} from 'lucide-react'; 
 import { ArrowUpFromLine } from 'lucide-react';
 import { Settings } from 'lucide-react';
 import { Volume2 } from 'lucide-react';
@@ -25,13 +25,10 @@ export default function Landing() {
             Start generating
           </a>
         </div>
-        <div className="hidden md:flex mt-70 mb-10 font-bold text-4xl text-center mx-auto w-fit">  
+        <div className="flex mt-70 mb-10 font-bold lg:text-4xl md:text-3xl text-2xl text-center mx-auto w-fit ">  
           Tailor studying to fit your needs
         </div>
 
-        <div className="md:hidden mt-70 mb-10 font-bold text-3xl text-center mx-auto w-fit  ">  
-                    Tailor studying to fit your needs
-        </div>
 
       <div className="py-12">
         <div className="flex flex-col md:flex-row items-center justify-center gap-8">

--- a/voicenotes/src/app/frontend/landing.js
+++ b/voicenotes/src/app/frontend/landing.js
@@ -6,12 +6,10 @@ export default function Landing() {
 
     return (
         <div className="mt-70 m-14">
-            <h1 className="hidden md:flex text-9xl tracking-wider">
+            <h1 className="flex lg:text-9xl md:text-8xl text-6xl tracking-wider">
                 VoiceNotes
             </h1>
-            <h1 className="md:hidden text-8xl tracking-wider">
-                VoiceNotes
-            </h1>
+
         </div>
     )
 

--- a/voicenotes/src/app/globals.css
+++ b/voicenotes/src/app/globals.css
@@ -18,6 +18,7 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+
 }
 
 html {

--- a/voicenotes/src/app/page.js
+++ b/voicenotes/src/app/page.js
@@ -15,7 +15,7 @@ export default function Home() {
     
     <div className="min-h-screen font-[family-name:var(--font-geist-sans)]">
       <NavBar />
-      <main className="flex flex-col items-center justify-center flex-grow">
+      <main className="flex flex-col items-center justify-center flex-grow overflow-x-hidden ">
 
       {loadingScreen && (<div id="loading" className="fixed inset-0 min-h-screen min-w-screen bg-white/85 content-center items-center text-center z-2">
 


### PR DESCRIPTION
## Summary by Sourcery

Improve mobile responsiveness by consolidating duplicate headings into single elements with responsive font sizes and adding overflow-x-hidden to prevent horizontal scrolling

Enhancements:
- Consolidate two `<h1>` elements in landing page into one with responsive text-size classes
- Merge duplicate about-section headlines into a single flex container with responsive font sizes
- Add `overflow-x-hidden` to the main layout to prevent horizontal overflow

Chores:
- Add spacing adjustment in globals.css